### PR TITLE
Inserindo valor inicial no Reduce

### DIFF
--- a/my-money-app/frontend/src/billingCycle/billingCycleForm.jsx
+++ b/my-money-app/frontend/src/billingCycle/billingCycleForm.jsx
@@ -13,8 +13,8 @@ class BillingCycleForm extends Component {
     calculateSummary() {
         const sum = (t, v) => t + v
         return {
-            sumOfCredits: this.props.credits.map(c => +c.value || 0).reduce(sum),
-            sumOfDebts: this.props.debts.map(d => +d.value || 0).reduce(sum)
+            sumOfCredits: this.props.credits.map(c => +c.value || 0).reduce(sum, 0),
+            sumOfDebts: this.props.debts.map(d => +d.value || 0).reduce(sum, 0)
         }
     }
 


### PR DESCRIPTION
Quando o **reduce** não tem um valor inicial, acontece o seguinte erro ao tentar editar ou excluir um item que não possui créditos e débitos (ou seja, um array vazio):
<img width="1426" alt="screen shot 2017-10-02 at 01 50 03" src="https://user-images.githubusercontent.com/16060332/31064577-16a62a60-a714-11e7-863d-ed1fb0f70b24.png">
Impossibilitando a exclusão ou edição do mesmo.




